### PR TITLE
Handle alloc failure

### DIFF
--- a/scripts/init-hugetlbfs.sh
+++ b/scripts/init-hugetlbfs.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 [ -d "/mnt/huge" ] || mkdir /mnt/huge
 mount | grep hugetlbfs || mount -t hugetlbfs none /mnt/huge
-echo 1024 > /proc/sys/vm/nr_hugepages
+echo 2048 > /proc/sys/vm/nr_hugepages
 

--- a/scripts/mlptest.sh
+++ b/scripts/mlptest.sh
@@ -25,10 +25,16 @@ killall latency-mlp >& /dev/null
 
 for l in `seq 1 $mlp`; do
     for c in `seq $c_start $c_end`; do
-	latency-mlp -c $c -l $l -i 20000 $ALLOC_MODE >& /dev/null &
+	    latency-mlp -c $c -l $l -i 20000 $ALLOC_MODE >& /dev/null &
     done
     sleep 0.5
-    latency-mlp -c $st -l $l -i 100 $ALLOC_MODE 2> /dev/null
+    latency-mlp -c $st -l $l -i 100 $ALLOC_MODE 2> /tmp/err.txt
+
+    if grep -qi "alloc failed" /tmp/err.txt; then
+        echo "Error: Failed to allocate memory for mlp $l, please allocate more hugepages." >&2
+        echo "Hint: Check /proc/meminfo and init-hugetlbfs.sh" >&2
+        exit 1
+    fi
     killall latency-mlp >& /dev/null
     echoerr  $l `tail -n 1 /tmp/test.txt`
 done  > /tmp/test.txt


### PR DESCRIPTION
Add error handling for the potential memory allocation failure in mlptest.sh. Also make sure that init-hugetlbfs.sh allocates enough pages to handle the default code.